### PR TITLE
Spoon shell (WIP)

### DIFF
--- a/cmd/spoon/bucket.go
+++ b/cmd/spoon/bucket.go
@@ -39,7 +39,12 @@ This command accepts one or two arguments. Either a known bucket (see spoon buck
 					return nil, cobra.ShellCompDirectiveNoFileComp
 				}
 
-				knownBuckets, err := getKnownBucketsFlat()
+				defaultScoop, err := scoop.NewScoop()
+				if err != nil {
+					return nil, cobra.ShellCompDirectiveNoFileComp
+				}
+
+				knownBuckets, err := getKnownBucketsFlat(defaultScoop)
 				if err != nil {
 					return nil, cobra.ShellCompDirectiveDefault
 				}
@@ -64,7 +69,11 @@ This command accepts one or two arguments. Either a known bucket (see spoon buck
 			),
 			Args: cobra.MinimumNArgs(1),
 			ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-				buckets, err := scoop.GetLocalBuckets()
+				defaultScoop, err := scoop.NewScoop()
+				if err != nil {
+					return nil, cobra.ShellCompDirectiveNoFileComp
+				}
+				buckets, err := defaultScoop.GetLocalBuckets()
 				if err != nil {
 					return nil, cobra.ShellCompDirectiveNoFileComp
 				}
@@ -83,7 +92,12 @@ This command accepts one or two arguments. Either a known bucket (see spoon buck
 				return bucketNames, cobra.ShellCompDirectiveDefault
 			},
 			Run: func(cmd *cobra.Command, args []string) {
-				buckets, err := scoop.GetLocalBuckets()
+				defaultScoop, err := scoop.NewScoop()
+				if err != nil {
+					fmt.Println("error getting default scoop:", err)
+					os.Exit(1)
+				}
+				buckets, err := defaultScoop.GetLocalBuckets()
 				if err != nil {
 					fmt.Println(err)
 					os.Exit(1)
@@ -127,7 +141,13 @@ This command accepts one or two arguments. Either a known bucket (see spoon buck
 		Use:   "known",
 		Short: "Lists all known buckets",
 		Run: func(cmd *cobra.Command, args []string) {
-			knownBuckets, err := getKnownBucketsFlat()
+			defaultScoop, err := scoop.NewScoop()
+			if err != nil {
+				fmt.Println("error getting default scoop:", err)
+				os.Exit(1)
+			}
+
+			knownBuckets, err := getKnownBucketsFlat(defaultScoop)
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)
@@ -158,7 +178,7 @@ This command accepts one or two arguments. Either a known bucket (see spoon buck
 	return bucketRoot
 }
 
-func getKnownBucketsFlat() ([]string, error) {
+func getKnownBucketsFlat(scoop *scoop.Scoop) ([]string, error) {
 	knownBuckets, err := scoop.GetKnownBuckets()
 	if err != nil {
 		return nil, fmt.Errorf("error getting known buckets: %w", err)

--- a/cmd/spoon/cat.go
+++ b/cmd/spoon/cat.go
@@ -22,7 +22,12 @@ func catCmd() *cobra.Command {
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: autocompleteAvailable,
 		Run: func(cmd *cobra.Command, args []string) {
-			app, err := scoop.GetAvailableApp(args[0])
+			defaultScoop, err := scoop.NewScoop()
+			if err != nil {
+				fmt.Println("error getting default scoop:", err)
+				os.Exit(1)
+			}
+			app, err := defaultScoop.GetAvailableApp(args[0])
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)

--- a/cmd/spoon/complete.go
+++ b/cmd/spoon/complete.go
@@ -8,7 +8,12 @@ import (
 )
 
 func autocompleteAvailable(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	buckets, err := scoop.GetLocalBuckets()
+	defaultScoop, err := scoop.NewScoop()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	buckets, err := defaultScoop.GetLocalBuckets()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
@@ -33,14 +38,22 @@ func autocompleteAvailable(cmd *cobra.Command, args []string, toComplete string)
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 	return matches, cobra.ShellCompDirectiveDefault
-
 }
 
-func autocompleteInstalled(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func autocompleteInstalled(
+	cmd *cobra.Command,
+	args []string,
+	toComplete string,
+) ([]string, cobra.ShellCompDirective) {
 	toComplete = strings.ToLower(toComplete)
 	var matches []string
 
-	apps, err := scoop.GetInstalledApps()
+	defaultScoop, err := scoop.NewScoop()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	apps, err := defaultScoop.GetInstalledApps()
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}

--- a/cmd/spoon/depends.go
+++ b/cmd/spoon/depends.go
@@ -23,7 +23,12 @@ func dependsCmd() *cobra.Command {
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: autocompleteAvailable,
 		Run: func(cmd *cobra.Command, args []string) {
-			app, err := scoop.GetAvailableApp(args[0])
+			defaultScoop, err := scoop.NewScoop()
+			if err != nil {
+				fmt.Println("error getting default scoop:", err)
+				os.Exit(1)
+			}
+			app, err := defaultScoop.GetAvailableApp(args[0])
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)
@@ -44,7 +49,7 @@ func dependsCmd() *cobra.Command {
 			// 4. Speed up
 
 			if reverse {
-				buckets, err := scoop.GetLocalBuckets()
+				buckets, err := defaultScoop.GetLocalBuckets()
 				if err != nil {
 					fmt.Println(err)
 					os.Exit(1)
@@ -68,10 +73,10 @@ func dependsCmd() *cobra.Command {
 					apps = append(apps, bucketApps...)
 				}
 
-				tree := app.ReverseDependencyTree(apps)
+				tree := defaultScoop.ReverseDependencyTree(apps, app)
 				printDeps(0, tree)
 			} else {
-				tree, err := app.DependencyTree()
+				tree, err := defaultScoop.DependencyTree(app)
 				if err != nil {
 					fmt.Println(err)
 					os.Exit(1)

--- a/cmd/spoon/main.go
+++ b/cmd/spoon/main.go
@@ -43,9 +43,8 @@ func main() {
 	if err := rootCmd.Execute(); err != nil {
 		if strings.HasPrefix(err.Error(), "unknown command") {
 			fmt.Println("Delegating to scoop ...")
-			execScoopCommand(os.Args[1], os.Args[2:]...)
+			os.Exit(execScoopCommand(os.Args[1], os.Args[2:]...))
 		} else {
-			fmt.Println("error:", err)
 			os.Exit(1)
 		}
 	}

--- a/cmd/spoon/main.go
+++ b/cmd/spoon/main.go
@@ -35,6 +35,7 @@ func main() {
 	rootCmd.AddCommand(updateCmd())
 	rootCmd.AddCommand(bucketCmd())
 	rootCmd.AddCommand(catCmd())
+	rootCmd.AddCommand(shellCmd())
 	rootCmd.AddCommand(statusCmd())
 	rootCmd.AddCommand(infoCmd())
 	rootCmd.AddCommand(dependsCmd())

--- a/cmd/spoon/shell.go
+++ b/cmd/spoon/shell.go
@@ -1,14 +1,150 @@
 package main
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
+	"syscall"
+	"unsafe"
 
 	"github.com/Bios-Marcel/spoon/pkg/scoop"
 	"github.com/spf13/cobra"
 )
+
+var (
+	modKernel32                  = syscall.NewLazyDLL("kernel32.dll")
+	procCloseHandle              = modKernel32.NewProc("CloseHandle")
+	procCreateToolhelp32Snapshot = modKernel32.NewProc("CreateToolhelp32Snapshot")
+	procProcess32First           = modKernel32.NewProc("Process32FirstW")
+	procProcess32Next            = modKernel32.NewProc("Process32NextW")
+)
+
+// PROCESSENTRY32 is a process as defined by Windows. We've simple padded
+// everything with unused field, to be able to parse everything and indicate
+// that the fields are unused at the same time.
+type PROCESSENTRY32 struct {
+	Size            uint32
+	_               uint32
+	ProcessID       uint32
+	_               uintptr
+	_               uint32
+	_               uint32
+	ParentProcessID uint32
+	_               int32
+	_               uint32
+	// ExeFile is expected to be at max 260 chars, as windows by default doesn't
+	// support long paths. While this could fail, we'll ignore this for now, as
+	// it is unlikely to happen.
+	ExeFile [260]uint16
+}
+
+func GetShellExecutable() (string, error) {
+	parentProcess, err := os.FindProcess(os.Getppid())
+	if err != nil {
+		return "", fmt.Errorf("error getting parent process: %w", err)
+	}
+
+	handle, _, _ := procCreateToolhelp32Snapshot.Call(0x00000002, 0)
+	if handle < 0 {
+		return "", syscall.GetLastError()
+	}
+	defer procCloseHandle.Call(handle)
+
+	var entry PROCESSENTRY32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	ret, _, _ := procProcess32First.Call(handle, uintptr(unsafe.Pointer(&entry)))
+	if ret == 0 {
+		return "", errors.New("error reading process entry")
+	}
+
+	for {
+		if int(entry.ProcessID) == parentProcess.Pid {
+			var name string
+			for index, char := range entry.ExeFile {
+				if char == 0 {
+					name = syscall.UTF16ToString(entry.ExeFile[:index])
+					break
+				}
+			}
+
+			if name == "" {
+				return "", errors.New("error reading process name")
+			}
+
+			return name, nil
+		}
+
+		ret, _, _ := procProcess32Next.Call(handle, uintptr(unsafe.Pointer(&entry)))
+		if ret == 0 {
+			break
+		}
+	}
+
+	return "", errors.New("shell not found")
+}
+
+// FIXME Implement properly at some point
+func createJunction(from, to string) error {
+	// No need to re-create a junction
+	if _, err := os.Stat(to); err == nil {
+		return nil
+	}
+
+	cmd := exec.Command("cmd", "/c", "mklink", "/J", to, from)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error creating junction: %w", err)
+	}
+
+	return nil
+}
+
+func GetUserPath() (string, error) {
+	cmd := exec.Command(
+		"powershell",
+		"[Environment]::GetEnvironmentVariable('PATH', 'User')",
+	)
+	pipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", fmt.Errorf("error opening pipe: %w", err)
+	}
+	var stringBuffer bytes.Buffer
+
+	var cmdErr error
+	go func() {
+		cmdErr = cmd.Run()
+	}()
+
+	if _, err := io.Copy(&stringBuffer, pipe); err != nil {
+		return "", err
+	}
+
+	if cmdErr != nil {
+		return "", cmdErr
+	}
+
+	return stringBuffer.String(), nil
+}
+
+func PersistUserPath(value string) error {
+	pathRestoreCmd := exec.Command(
+		"powershell",
+		"-Command",
+		"[Environment]::SetEnvironmentVariable('PATH','"+value+"','User')",
+	)
+	pathRestoreCmd.Stdout = os.Stdout
+	pathRestoreCmd.Stderr = os.Stderr
+	pathRestoreCmd.Stdin = os.Stdin
+	return pathRestoreCmd.Run()
+}
 
 func shellCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -17,19 +153,70 @@ func shellCmd() *cobra.Command {
 		Args:              cobra.MinimumNArgs(1),
 		ValidArgsFunction: autocompleteAvailable,
 		Run: func(cmd *cobra.Command, args []string) {
+			// If we are using PowershellCore, we can't user PowershellDesktop
+			// and vice versa, as the module paths will cause conflicts, causing
+			// us to not find `Get-FileHash` for example.
+			shell, err := GetShellExecutable()
+			if err != nil {
+				fmt.Println("error determining shell:", err)
+				os.Exit(1)
+			}
+
+			shell = strings.ToLower(shell)
+			switch shell {
+			case "pwsh.exe", "powershell.exe":
+				break
+			default:
+				// If the user runs something else, such as nushell or cmd, we
+				// will fallback to default powershell for now.
+				shell = "powershell.exe"
+			}
+
+			// Windows has User-Level and System-Level PATHs. When calling
+			// os.GetEnv, you always get the combined PATH. Since scoop
+			// manipulates the User-Level PATH during install, we need to
+			// restore it to its old User-Level PATH, instead of the old
+			// combined PATH, as we pollute the path otherwise.
+			oldUserPath, err := GetUserPath()
+			if err != nil {
+				fmt.Println("error retrieving old user path:", err)
+				os.Exit(1)
+			}
+
+			tempScoopPath, err := filepath.Abs("./.scoop")
+			if err != nil {
+				fmt.Println("error getting abs scoop path:", err)
+				os.Exit(1)
+			}
+			oldCombinedPath := os.Getenv("PATH")
+			newShimPath := filepath.Join(tempScoopPath, "shims")
+			newTempPath := newShimPath + ";" + oldCombinedPath
+
+			env := os.Environ()
+			var scoopPathSet bool
+			// We want to keep the env in tact for subprocesses, as setting
+			// cmd.Env will actually overwrite the whole env.
+			for index, envVar := range env {
+				if strings.HasPrefix(envVar, "PATH=") {
+					env[index] = "PATH=" + newShimPath + ";" + strings.TrimPrefix(envVar, "PATH=")
+					continue
+				} else if strings.HasPrefix(envVar, "SCOOP=") {
+					env[index] = "SCOOP=" + tempScoopPath
+					// SCOOP var might not be present, so we need to append it
+					// if it wasn't overwritten already.
+					scoopPathSet = true
+				}
+			}
+			if !scoopPathSet {
+				env = append(env, "SCOOP="+tempScoopPath)
+			}
 			/*
 				TODO:
 
 				Support for different shells (pwsh / powershell / batch / bash / wsl?)
 				Support for custom powershell profiles
 				Proper support for subshelling
-				neofetch for example claims that git isn't installed
 			*/
-
-			// Already supports bucket/app@VERSION
-			if exitCode := execScoopCommand("download", args...); exitCode != 0 {
-				os.Exit(exitCode)
-			}
 
 			if err := os.MkdirAll("./.scoop/apps/scoop", os.ModeDir); err != nil {
 				fmt.Println("error creating temporary scoop dir: %w", err)
@@ -53,34 +240,28 @@ func shellCmd() *cobra.Command {
 				fmt.Println("error linking buckets:", err)
 				os.Exit(1)
 			}
-
-			tempScoopPath, err := filepath.Abs("./.scoop")
-			if err != nil {
-				fmt.Println("error getting abs scoop path:", err)
-				os.Exit(1)
-			}
-			oldPath := os.Getenv("PATH")
-			pathEnvVar := filepath.Join(tempScoopPath, "shims") + ";" + oldPath
 			scoopInstallCmd := exec.Command(
-				"pwsh.exe",
+				shell,
 				append(
-					append([]string{},
+					[]string{
 						"-NoProfile",
-						"-Command", filepath.Join(tempScoopPath, "apps", "scoop", "current", "bin", "scoop.ps1"),
+						"-Command",
+						"scoop",
 						"install",
-					),
+					},
 					args...,
 				)...,
 			)
-			scoopInstallCmd.Env = []string{
-				"SCOOP=" + tempScoopPath,
-				"PATH=" + pathEnvVar,
-			}
+			scoopInstallCmd.Env = env
 			scoopInstallCmd.Stdout = os.Stdout
 			scoopInstallCmd.Stderr = os.Stderr
 			scoopInstallCmd.Stdin = os.Stdin
 
 			if err := scoopInstallCmd.Run(); err != nil {
+				// Since we don't know whether the PATH was manipulated even on
+				// an unsuccessful install, we still need to restore it.
+				PersistUserPath(oldUserPath)
+
 				fmt.Println("error installing:", err)
 				os.Exit(1)
 			}
@@ -88,45 +269,23 @@ func shellCmd() *cobra.Command {
 			// Scoop forcibly adds the shim dir to the path in a persistent
 			// manner. We can't prevent this, but we can restore the previous
 			// state.
-			pathRestoreCmd := exec.Command("pwsh.exe", "-Command", "[Environment]::SetEnvironmentVariable('PATH','"+oldPath+"','User')")
-			pathRestoreCmd.Stdout = os.Stdout
-			pathRestoreCmd.Stderr = os.Stderr
-			pathRestoreCmd.Stdin = os.Stdin
-
-			if err := pathRestoreCmd.Run(); err != nil {
+			if err := PersistUserPath(oldUserPath); err != nil {
 				fmt.Println("error restoring path:", err)
 				os.Exit(1)
 			}
 
+			// Workaround, as starting a subshell on windows doesn't seem to be
+			// so easy after all.
 			os.WriteFile(
 				"shell.ps1",
 				// Not only do we need to temporary add our shims to the path,
 				// we also need to reset the temporary path, as this is carried
 				// over out of the subshell, why ever ...
-				[]byte(`$env:PATH="`+pathEnvVar+`"; pwsh.exe; $env:PATH="`+oldPath+`"`),
+				[]byte(`$env:PATH="`+newTempPath+`"; `+shell+`; $env:PATH="`+oldCombinedPath+`"`),
 				0o700,
 			)
 		},
 	}
 
 	return cmd
-}
-
-// FIXME Implement properly at some point
-func createJunction(from, to string) error {
-	// No need to re-create a junction
-	if _, err := os.Stat(to); err == nil {
-		return nil
-	}
-
-	cmd := exec.Command("cmd", "/c", "mklink", "/J", to, from)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdin
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("error creating junction: %w", err)
-	}
-
-	return nil
 }

--- a/cmd/spoon/shell.go
+++ b/cmd/spoon/shell.go
@@ -110,6 +110,7 @@ func createJunction(from, to string) error {
 func GetUserPath() (string, error) {
 	cmd := exec.Command(
 		"powershell",
+		"-NoProfile",
 		"[Environment]::GetEnvironmentVariable('PATH', 'User')",
 	)
 	pipe, err := cmd.StdoutPipe()
@@ -137,6 +138,7 @@ func GetUserPath() (string, error) {
 func PersistUserPath(value string) error {
 	pathRestoreCmd := exec.Command(
 		"powershell",
+		"-NoProfile",
 		"-Command",
 		"[Environment]::SetEnvironmentVariable('PATH','"+value+"','User')",
 	)
@@ -214,7 +216,6 @@ func shellCmd() *cobra.Command {
 				TODO:
 
 				Support for different shells (pwsh / powershell / batch / bash / wsl?)
-				Support for custom powershell profiles
 				Proper support for subshelling
 			*/
 

--- a/cmd/spoon/shell.go
+++ b/cmd/spoon/shell.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/Bios-Marcel/spoon/pkg/scoop"
+	"github.com/spf13/cobra"
+)
+
+func shellCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "shell",
+		Short:             "Create a subshell with the given applications on your PATH",
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: autocompleteAvailable,
+		Run: func(cmd *cobra.Command, args []string) {
+			/*
+				TODO:
+
+				Support for different shells (pwsh / powershell / batch / bash / wsl?)
+				Support for custom powershell profiles
+				Proper support for subshelling
+				neofetch for example claims that git isn't installed
+			*/
+
+			// Already supports bucket/app@VERSION
+			if exitCode := execScoopCommand("download", args...); exitCode != 0 {
+				os.Exit(exitCode)
+			}
+
+			if err := os.MkdirAll("./.scoop/apps/scoop", os.ModeDir); err != nil {
+				fmt.Println("error creating temporary scoop dir: %w", err)
+				os.Exit(1)
+			}
+
+			// FIXME Rework API for these calls to be less cancerous
+			cacheDir, _ := scoop.GetCacheDir()
+			installDir, _ := scoop.GetScoopInstallationDir()
+			bucketDir, _ := scoop.GetScoopBucketDir()
+
+			if err := createJunction(cacheDir, `.\.scoop\cache`); err != nil {
+				fmt.Println("error linking cache:", err)
+				os.Exit(1)
+			}
+			if err := createJunction(installDir, `.\.scoop\apps\scoop\current`); err != nil {
+				fmt.Println("error linking scoop installation:", err)
+				os.Exit(1)
+			}
+			if err := createJunction(bucketDir, `.\.scoop\buckets`); err != nil {
+				fmt.Println("error linking buckets:", err)
+				os.Exit(1)
+			}
+
+			tempScoopPath, err := filepath.Abs("./.scoop")
+			if err != nil {
+				fmt.Println("error getting abs scoop path:", err)
+				os.Exit(1)
+			}
+			oldPath := os.Getenv("PATH")
+			pathEnvVar := filepath.Join(tempScoopPath, "shims") + ";" + oldPath
+			scoopInstallCmd := exec.Command(
+				"pwsh.exe",
+				append(
+					append([]string{},
+						"-NoProfile",
+						"-Command", filepath.Join(tempScoopPath, "apps", "scoop", "current", "bin", "scoop.ps1"),
+						"install",
+					),
+					args...,
+				)...,
+			)
+			scoopInstallCmd.Env = []string{
+				"SCOOP=" + tempScoopPath,
+				"PATH=" + pathEnvVar,
+			}
+			scoopInstallCmd.Stdout = os.Stdout
+			scoopInstallCmd.Stderr = os.Stderr
+			scoopInstallCmd.Stdin = os.Stdin
+
+			if err := scoopInstallCmd.Run(); err != nil {
+				fmt.Println("error installing:", err)
+				os.Exit(1)
+			}
+
+			// Scoop forcibly adds the shim dir to the path in a persistent
+			// manner. We can't prevent this, but we can restore the previous
+			// state.
+			pathRestoreCmd := exec.Command("pwsh.exe", "-Command", "[Environment]::SetEnvironmentVariable('PATH','"+oldPath+"','User')")
+			pathRestoreCmd.Stdout = os.Stdout
+			pathRestoreCmd.Stderr = os.Stderr
+			pathRestoreCmd.Stdin = os.Stdin
+
+			if err := pathRestoreCmd.Run(); err != nil {
+				fmt.Println("error restoring path:", err)
+				os.Exit(1)
+			}
+
+			os.WriteFile(
+				"shell.ps1",
+				// Not only do we need to temporary add our shims to the path,
+				// we also need to reset the temporary path, as this is carried
+				// over out of the subshell, why ever ...
+				[]byte(`$env:PATH="`+pathEnvVar+`"; pwsh.exe; $env:PATH="`+oldPath+`"`),
+				0o700,
+			)
+		},
+	}
+
+	return cmd
+}
+
+// FIXME Implement properly at some point
+func createJunction(from, to string) error {
+	// No need to re-create a junction
+	if _, err := os.Stat(to); err == nil {
+		return nil
+	}
+
+	cmd := exec.Command("cmd", "/c", "mklink", "/J", to, from)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error creating junction: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/spoon/uninstall.go
+++ b/cmd/spoon/uninstall.go
@@ -31,7 +31,12 @@ func uninstallCmd() *cobra.Command {
 				fmt.Println("error getting yes flag:", err)
 				os.Exit(1)
 			}
-			if err := checkRunningProcesses(args, yes); err != nil {
+			defaultScoop, err := scoop.NewScoop()
+			if err != nil {
+				fmt.Println("error getting default scoop:", err)
+				os.Exit(1)
+			}
+			if err := checkRunningProcesses(defaultScoop, args, yes); err != nil {
 				fmt.Println(err)
 			}
 
@@ -51,20 +56,16 @@ func uninstallCmd() *cobra.Command {
 	return cmd
 }
 
-func checkRunningProcesses(args []string, yes bool) error {
+func checkRunningProcesses(scoop *scoop.Scoop, args []string, yes bool) error {
 	processes, err := wapi.ProcessList()
 	if err != nil {
 		return fmt.Errorf("error determining runing processes: %w", err)
 	}
 
-	appsDir, err := scoop.GetAppsDir()
-	if err != nil {
-		return err
-	}
-
 	var processPrefixes []string
 	for _, arg := range args {
-		processPrefixes = append(processPrefixes, strings.ToLower(filepath.Join(appsDir, arg)+"\\"))
+		processPrefixes = append(processPrefixes,
+			strings.ToLower(filepath.Join(scoop.GetAppsDir(), arg)+"\\"))
 	}
 
 	var processesToKill []shared.Process

--- a/cmd/spoon/util.go
+++ b/cmd/spoon/util.go
@@ -8,6 +8,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// RunE wraps the actual runE passed to cobra. This allows us to Silence the
+// Usage string if a non usage error occured.
+func RunE(
+	runE func(cmd *cobra.Command, args []string) error,
+) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := runE(cmd, args); err != nil {
+			cmd.SilenceUsage = true
+			return err
+		}
+		return nil
+	}
+}
+
 func execScoopCommand(command string, args ...string) int {
 	cmd := exec.Command("scoop", append(strings.Split(command, " "), args...)...)
 	cmd.Stdout = os.Stdout

--- a/pkg/scoop/scoop.go
+++ b/pkg/scoop/scoop.go
@@ -404,9 +404,26 @@ func GetScoopDir() (string, error) {
 	return filepath.Join(home, "scoop"), nil
 }
 
-// cachePathRegex applies the same rules to the name components as scoop does.
+// LookupCache will check the cache dir for matching entries. Note that the
+// `app` parameter must be non-empty, but the version is optional.
+func LookupCache(app, version string) ([]string, error) {
+	cacheDir, err := GetCacheDir()
+	if err != nil {
+		return nil, fmt.Errorf("error getting cache dir: %w", err)
+	}
+
+	expectedPrefix := cachePathRegex.ReplaceAllString(app, "_")
+	if version != "" {
+		expectedPrefix += "#" + cachePathRegex.ReplaceAllString(version, "_")
+	}
+
+	return filepath.Glob(filepath.Join(cacheDir, expectedPrefix+"*"))
+}
+
 var cachePathRegex = regexp.MustCompile(`[^\w\.\-]+`)
 
+// CachePath generates a path given the app, a version and the target URL. The
+// rules defined here are taken from the scoop code.
 func CachePath(app, version, url string) string {
 	parts := []string{app, version, url}
 	for i, part := range parts {


### PR DESCRIPTION
`spoon shell` is a command native to `spoon`. It uses scoop and some additional logic in order to provide something akin to `nix-shell`.

For now this will mostly use scoop as a backend, since the necessary elements haven't been implemented in spoon yet.

Supported shells for now are pwsh and powershell. It seems however, that subshelling isn't easily possible from within a go executable. So instead we generate a powershell file that requires manual execution.

An alternative approach would be, to actually provide a wrapper powershell script for spoon, so that we are already in a powershell context, allowing us to communicate to the wrapper that we'd like a subshell.

## Testing

TODO, make tests using windows native containers. (See wastebasket v2, i did it there too)

## Test PR

Install via:

```ps1
go install github.com/Bios-Marcel/spoon/cmd/spoon@spoon_shell
```

## Planned UX

```ps1
spoon shell setup apps...
```

Will create a `.scoop` folder containing the desired applications.
Additionally, we'll get a `shell.ps1` script that will open the subshell containing path entries for the locally installed applications.

Rerunning the same command with different apps will cleanup. This means that previously installed apps will be gone and new ones will be added.

```ps1
spoon shell clean
```

Will delete both `.scoop` and `shell.ps1`.

To make usage in a project easier, you can create a script such as `setup_scoop.ps1`:

```ps1
$packages = @(
    # Used for ...
    'lua',
    # Important to use this version because ...
    'golangci-lint@1.56.1',
    # Pinned node major version from versions bucket
    'versions/nodejs18'
)

spoon shell setup $packages
```

This way you can easily version your dependencies and document them.

## Notes

While there are similar tools to this, such as [devenv](https://devenv.sh/), it's not very Windows-native. But `spoon shell` works outside of WSL (support inside WSL soonTM).

This would also obsolete tools such as [nvm](https://github.com/nvm-sh/nvm).